### PR TITLE
alma collectionID check hardening

### DIFF
--- a/lib/AlmaClient/AlmaClient.class.php
+++ b/lib/AlmaClient/AlmaClient.class.php
@@ -774,10 +774,11 @@ class AlmaClient {
             foreach ($issue_holdings->getElementsByTagName('holding') as $issue_holding) {
               $total_count += (int) $issue_holding->getAttribute('nofTotal') + (int) $issue_holding->getAttribute('nofOrdered');
               if ($issue_holding->getAttribute('showReservationButton') == 'yes') {
-                    $test = $issue_holding->hasAttribute ('collectionId') ?  $issue_holding->getAttribute('collectionId') : "";
-                    if($test != null && $test != "" && array_key_exists($test, $nonreservable_collections))
+                    $collectionId = $issue_holding->hasAttribute ('collectionId') ?  $issue_holding->getAttribute('collectionId') : "";
+                    if($collectionId != null && $collectionId != "" && array_key_exists($collectionId, $nonreservable_collections))
                     {
-                        watchdog('issue_holding', 'Test or unreserveable collection hit.', array(), WATCHDOG_NOTICE, $link = NULL);
+                        //collection is not reserveable.
+                        //watchdog('issue_holding', 'Test or unreserveable collection hit.', array(), WATCHDOG_NOTICE, $link = NULL);
                     }
                     else
                     {

--- a/lib/AlmaClient/AlmaClient.class.php
+++ b/lib/AlmaClient/AlmaClient.class.php
@@ -773,11 +773,18 @@ class AlmaClient {
             }
             foreach ($issue_holdings->getElementsByTagName('holding') as $issue_holding) {
               $total_count += (int) $issue_holding->getAttribute('nofTotal') + (int) $issue_holding->getAttribute('nofOrdered');
-              if (($issue_holding->getAttribute('showReservationButton') == 'yes') &&
-                  (!array_key_exists($issue_holding->getAttribute('collectionId'), $nonreservable_collections))) {
-                $reservable_count += (int) $issue_holding->getAttribute('nofOrdered') + (int) $issue_holding->getAttribute('nofTotal');
+              if ($issue_holding->getAttribute('showReservationButton') == 'yes') {
+                    $test = $issue_holding->hasAttribute ('collectionId') ?  $issue_holding->getAttribute('collectionId') : "";
+                    if($test != null && $test != "" && array_key_exists($test, $nonreservable_collections))
+                    {
+                        watchdog('issue_holding', 'Test or unreserveable collection hit.', array(), WATCHDOG_NOTICE, $link = NULL);
+                    }
+                    else
+                    {
+                        $reservable_count += (int) $issue_holding->getAttribute('nofOrdered') + (int) $issue_holding->getAttribute('nofTotal');
+                    }
+                }
               }
-            }
             $issue_list = array(
               'local_id' => $holdings[0]['local_id'],
               'reservable_count' => $reservable_count,
@@ -790,7 +797,7 @@ class AlmaClient {
         }
       }
     }
-
+    
     return $record;
   }
 


### PR DESCRIPTION
New scientist collections do not all have collectid's and it seems in php5.3 the xml is handled differently then in 5.5 and thus it gives false non reserveables.
